### PR TITLE
Sort special supervision

### DIFF
--- a/src/ClientApp/src/components/Filters/Filters.js
+++ b/src/ClientApp/src/components/Filters/Filters.js
@@ -102,7 +102,17 @@ const sqlMap = {
 
             return query.join(' OR ');
         },
-        supervision: data => `special_supervision='${data.map(item => item.id).join(', ')}'`,
+        supervision: data => `special_supervision='${data.sort((a, b) => {
+            if (a.sortKey < b.sortKey) {
+                return -1;
+            }
+
+            if (a.sortKey > b.sortKey) {
+                return 1;
+            }
+
+            return 0;
+        }).map(item => item.id).join(', ')}'`,
         gang: data => `gang_type in (${data.map(item => `'${item.name.toUpperCase()}'`).join()})`,
         offense: data => `offense_code in (${data.map(item => `'${item.id}'`).join()})`
     }

--- a/src/ClientApp/src/components/Filters/Filters.test.js
+++ b/src/ClientApp/src/components/Filters/Filters.test.js
@@ -198,5 +198,78 @@ describe('sqlMapper', () => {
       expect(actual.filter[5]).toBe("offense_code in ('E')");
       expect(actual.definitionExpression.length).toBe(0);
     });
+
+    it('orders special supervisions', () => {
+      const payload = [
+        {
+          "name": "EM",
+          "id": "EM",
+          "default": true,
+          "sortKey": 8
+        },
+        {
+          "name": "SO",
+          "id": "SO",
+          "default": true,
+          "sortKey": 2
+        },
+        {
+          "name": "SO-A",
+          "id": "SO-A",
+          "default": true,
+          "sortKey": 18
+        },
+        {
+          "name": "SO-B",
+          "id": "SO-B",
+          "default": true,
+          "sortKey": 19
+        },
+        {
+          "name": "SO-C",
+          "id": "SO-C",
+          "default": true,
+          "sortKey": 22
+        },
+        {
+          "name": "DORA",
+          "id": "DORA",
+          "default": true,
+          "sortKey": 1
+        },
+        {
+          "name": "ECR",
+          "id": "ECR",
+          "default": true,
+          "sortKey": 17
+        },
+        {
+          "name": "FOSI",
+          "id": "FOSI",
+          "default": true,
+          "sortKey": 21
+        },
+        {
+          "name": "IG INT",
+          "id": "IG INT",
+          "default": true,
+          "sortKey": 20
+        },
+        {
+          "name": "MIO",
+          "id": "MIO",
+          "default": true,
+          "sortKey": 10
+        }
+      ];
+
+      const actual = sqlMapper({
+        other: {
+          supervision: payload
+        }
+      });
+
+      expect(actual.filter[0]).toBe("special_supervision='DORA, SO, EM, MIO, ECR, SO-A, SO-B, IG INT, FOSI, SO-C'");
+    });
   });
 });

--- a/src/ClientApp/src/components/Filters/lookupData.js
+++ b/src/ClientApp/src/components/Filters/lookupData.js
@@ -1,79 +1,98 @@
 const supervisionItems = [{
     name: 'CCC',
     id: 'CCC',
-    default: false
+    default: false,
+    sortKey: 11
 }, {
     name: 'PVP',
     id: 'PVP',
-    default: false
+    default: false,
+    sortKey: 16
 }, {
     name: 'COMP',
     id: 'COMP',
-    default: false
+    default: false,
+    sortKey: 6
 }, {
     name: 'DEP',
     id: 'DEP',
-    default: false
+    default: false,
+    sortKey: 12
 }, {
     name: 'EM',
     id: 'EM',
-    default: true
+    default: true,
+    sortKey: 8
 }, {
     name: 'GPS',
     id: 'GPS',
-    default: true
+    default: true,
+    sortKey: 7
 }, {
     name: 'SO',
     id: 'SO',
-    default: true
+    default: true,
+    sortKey: 2
 }, {
     name: 'SO-A',
     id: 'SO-A',
-    default: true
+    default: true,
+    sortKey: 18
 }, {
     name: 'SO-B',
     id: 'SO-B',
-    default: true
+    default: true,
+    sortKey: 19
 }, {
     name: 'SO-C',
     id: 'SO-C',
-    default: true
+    default: true,
+    sortKey: 22
 }, {
     name: 'FUG',
     id: 'FUG',
-    default: false
+    default: false,
+    sortKey: 3
 }, {
     name: 'INCAR',
     id: 'INCAR',
-    default: false
+    default: false,
+    sortKey: 4
 }, {
     name: 'RESID',
     id: 'RESID',
-    default: false
+    default: false,
+    sortKey: 5
 }, {
     name: 'DRUG CT',
     id: 'DRUG CT',
-    default: false
+    default: false,
+    sortKey: 15
 }, {
     name: 'DORA',
     id: 'DORA',
-    default: true
+    default: true,
+    sortKey: 1
 }, {
     name: 'ECR',
     id: 'ECR',
-    default: true
+    default: true,
+    sortKey: 17
 }, {
     name: 'FOSI',
     id: 'FOSI',
-    default: true
+    default: true,
+    sortKey: 21
 }, {
     name: 'IG INT',
     id: 'IG INT',
-    default: true
+    default: true,
+    sortKey: 20
 }, {
     name: 'MIO',
     id: 'MIO',
-    default: true
+    default: true,
+    sortKey: 10
 }];
 
 const mainGangs = [{


### PR DESCRIPTION
This sorts the special supervisions as per the wiki.

I'm not sure this is how the agents will expect this filter to work as it is doing an exact match.

For example, if an agent enters `DORA` they will match offenders having **only** a `DORA` entry. If the offender has more than `DORA`, eg: `DORA, SO`, the offender will be omitted. 

@nathankota Please ask the DOC how they expect this filter to work and we can see if we can align it.